### PR TITLE
New homescreen

### DIFF
--- a/docs/animations/garden-animation.md
+++ b/docs/animations/garden-animation.md
@@ -1,0 +1,330 @@
+# Garden Animation
+
+**File:** `src/scripts/garden/gardenAnimation.ts`
+
+The garden page features an interactive curved strip with plants, trees, flowers, procedural grass, and a character that walks/runs along the curve as the user scrolls. This is the most complex animation in the project.
+
+---
+
+## Table of Contents
+
+1. [Setup & Plugin Registration](#setup--plugin-registration)
+2. [Responsive Scaling](#responsive-scaling)
+3. [Strip Shrink & Curve Flatten (Scroll-Driven)](#strip-shrink--curve-flatten)
+4. [Sticky Bar Visibility](#sticky-bar-visibility)
+5. [Character Walking Along the Curve](#character-walking-along-the-curve)
+6. [Curve Math (curveUtils)](#curve-math-curveutils)
+7. [Procedural Grass (grassCanvas)](#procedural-grass-grasscanvas)
+
+---
+
+## Setup & Plugin Registration
+
+Every GSAP animation file in this project follows the same boilerplate:
+
+```ts
+import gsap from 'gsap';
+import ScrollTrigger from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+```
+
+**Why `registerPlugin`?** GSAP uses a modular architecture. ScrollTrigger is a separate plugin that hooks into GSAP's core. You must register it before using any `scrollTrigger` config in your animations. If you skip this, ScrollTrigger silently does nothing.
+
+**Real-world analogy:** Think of it like plugging in a USB device. GSAP is the computer, ScrollTrigger is the device. You need to "plug it in" (register) before it works.
+
+---
+
+## Responsive Scaling
+
+```ts
+const BASE_HEIGHT = 220;
+const BASE_B = 110;
+
+function getScale(): number {
+  return Math.min(BASE_HEIGHT, window.innerHeight * 0.5) / BASE_HEIGHT;
+}
+```
+
+The garden strip is designed for a base height of 220px. On smaller viewports (where 50% of the screen height is less than 220), everything scales down proportionally.
+
+**How it works:**
+- On a 900px tall screen: `Math.min(220, 450) / 220 = 1.0` (full size)
+- On a 400px tall screen: `Math.min(220, 200) / 220 = 0.91` (slightly smaller)
+
+This scale factor (`s`) is then applied to:
+- The strip height: `BASE_HEIGHT * s`
+- The curve radius: `BASE_B * s`
+- The character height: `BASE_CHAR_HEIGHT * s`
+
+**Real-world example:** This is the same technique responsive games use. Instead of writing media queries for every element, you calculate one scale factor and multiply everything by it.
+
+---
+
+## Strip Shrink & Curve Flatten
+
+This is the hero animation of the garden page. As the user scrolls past the intro section, the curved green strip shrinks and flattens:
+
+```ts
+ScrollTrigger.create({
+  id: 'intro-strip',
+  trigger: '.intro-section',
+  start: 'top top',
+  end: 'bottom top',
+  scrub: true,
+  onUpdate(self) {
+    const p = self.progress; // 0 at start, 1 at end
+
+    gsap.set('.garden-strip', {
+      height: baseH - (baseH - minH) * p,
+      borderRadius: `${50 * (1 - p)}% ${50 * (1 - p)}% 0 0 / ${bMax * (1 - p)}px ...`,
+    });
+
+    gsap.set('.garden-description', { opacity: 1 - p });
+  },
+});
+```
+
+### Key Concepts
+
+**`scrub: true`** — This is the magic. Instead of playing the animation once, `scrub` ties the animation progress directly to scroll position. Scroll halfway = animation is 50% complete. Scroll back up = animation reverses. It makes the animation feel like the user is "controlling" it with their scroll.
+
+**`self.progress`** — A value from 0 to 1 representing how far through the scroll range you are. We use this to interpolate between start and end values.
+
+**`gsap.set()` vs `gsap.to()`** — `set()` applies values immediately (no animation). We use `set()` here because ScrollTrigger is already providing the "animation" through scroll progress. We just need to update the values at each scroll frame.
+
+**`start: 'top top'`** — Means "when the TOP of the trigger element reaches the TOP of the viewport". The format is always `'triggerPosition viewportPosition'`.
+
+**`end: 'bottom top'`** — Means "when the BOTTOM of the trigger reaches the TOP of the viewport" (i.e., the element has fully scrolled past).
+
+**The border-radius trick:**
+
+```
+borderRadius: 50% 50% 0 0 / 110px 110px 0 0
+```
+
+This creates an elliptical curve on the top edge of the strip. The `/` separates horizontal and vertical radii. As `p` goes from 0 to 1, both values shrink to 0, making the curve flatten into a straight line.
+
+**Real-world example:** Think of Apple's product pages where a hero image scales, fades, or transforms as you scroll. The same technique — `scrub: true` + `onUpdate` — powers those effects.
+
+---
+
+## Sticky Bar Visibility
+
+```ts
+ScrollTrigger.create({
+  trigger: '.garden-cards-section',
+  start: 'top center',
+  end: 'top top',
+  onEnter: () => {
+    stickyBar.classList.remove('opacity-0', 'pointer-events-none');
+    stickyBar.classList.add('opacity-100');
+  },
+  onLeaveBack: () => {
+    stickyBar.classList.add('opacity-0', 'pointer-events-none');
+    stickyBar.classList.remove('opacity-100');
+  },
+});
+```
+
+This uses ScrollTrigger as a **scroll-position detector** rather than an animation driver. No `scrub`, no `gsap.to()` — just callbacks.
+
+**`onEnter`** fires when you scroll INTO the trigger zone. **`onLeaveBack`** fires when you scroll BACK OUT of it (upward). Together they create a toggle: show the sticky bar when cards are visible, hide it when you scroll back up.
+
+**Why CSS classes instead of GSAP?** The sticky bar uses Tailwind's `opacity-0` / `opacity-100` and CSS transitions. Since the transition is a simple binary toggle (not scroll-driven), CSS handles it more cleanly.
+
+**Real-world example:** This pattern is everywhere — navigation bars that appear/disappear based on scroll position, "back to top" buttons, floating action buttons.
+
+---
+
+## Character Walking Along the Curve
+
+The most creative animation: a sprite character that walks or runs along the garden's curved strip as you scroll through the cards section.
+
+```ts
+ScrollTrigger.create({
+  trigger: '.garden-cards-section',
+  start: 'top 50%',
+  end: 'bottom bottom',
+  onUpdate(self) {
+    const p = self.progress;
+    const targetX = 10 + p * (vw - 110); // left edge → right edge
+
+    const currentX = gsap.getProperty(character, 'x') as number;
+    const distance = Math.abs(targetX - currentX);
+
+    if (distance < 5) return; // dead zone to prevent jitter
+
+    // Choose walk or run based on how far behind the character is
+    character.dataset.facingRight = String(targetX > currentX);
+    const isRunning = distance > RUN_THRESHOLD; // 250px
+    character.dataset.motion = isRunning ? 'run' : 'walk';
+
+    if (walkTween) walkTween.kill(); // cancel previous animation
+
+    const speed = isRunning ? RUN_SPEED : WALK_SPEED;
+    const duration = Math.max(0.3, Math.min(2, distance / speed));
+
+    walkTween = gsap.to(character, {
+      x: targetX,
+      duration,
+      ease: 'none',
+      onUpdate() {
+        // Keep character on the curve as it moves horizontally
+        const cx = gsap.getProperty(character, 'x') as number;
+        gsap.set(character, {
+          y: curveY(20 + cx, vw, b) - charHeight,
+        });
+      },
+      onComplete() {
+        character.dataset.motion = 'idle';
+      },
+    });
+  },
+});
+```
+
+### How it works, step by step
+
+1. **Scroll progress maps to a target X position.** At 0% scroll, the character should be at the left. At 100%, at the right.
+
+2. **Dead zone.** If the character is already within 5px of the target, do nothing. This prevents micro-jittering from tiny scroll events.
+
+3. **Walk vs run.** If the character needs to cover more than 250px, it runs (faster sprite animation). Otherwise it walks. This is set via `data-motion` attributes that CSS uses to switch sprite sheet animations.
+
+4. **Kill previous tween.** If the user scrolls again before the character finishes moving, we cancel the old animation and start a fresh one toward the new target. This makes the movement feel responsive.
+
+5. **Duration from distance.** `distance / speed` gives a realistic duration — farther = longer. Clamped between 0.3s and 2s to prevent extremes.
+
+6. **`onUpdate` — stay on the curve.** As the character moves horizontally (`x`), we continuously recalculate its vertical position using `curveY()` so it follows the curved strip surface.
+
+7. **`onComplete` — go idle.** When the character reaches its target, switch back to the idle sprite frame.
+
+**Real-world example:** This is similar to how platformer games work — a character follows terrain geometry. The scroll position acts as a "controller input" that sets where the character should move to.
+
+---
+
+## Curve Math (curveUtils)
+
+**File:** `src/scripts/garden/curveUtils.ts`
+
+### curveY — Point on an ellipse
+
+```ts
+export function curveY(x: number, stripWidth: number, b: number): number {
+  const t = 2 * (x / stripWidth) - 1; // normalize x to [-1, 1]
+  const inner = 1 - t * t;
+  return inner <= 0 ? b : b * (1 - Math.sqrt(inner));
+}
+```
+
+This calculates the Y position on an elliptical curve. The strip's top edge is shaped like the top half of an ellipse.
+
+**The math:**
+- An ellipse equation: `(x/a)^2 + (y/b)^2 = 1`
+- Solving for y: `y = b * sqrt(1 - (x/a)^2)`
+- We normalize x to `[-1, 1]` so the ellipse spans the full strip width
+- `b` is the curve height (vertical radius). When `b = 110`, the curve dips 110px. When `b = 0`, it's flat.
+
+**Real-world example:** This is how you'd draw any arch or dome shape in code — the same math that describes the St. Louis Gateway Arch (which is actually a catenary, but close enough!).
+
+### curveNormalAngle — Angle perpendicular to the curve
+
+```ts
+export function curveNormalAngle(x: number, w: number, b: number): number {
+  const t = 2 * (x / w) - 1;
+  const inner = 1 - t * t;
+  const dydx = (2 * b / w) * t / Math.sqrt(inner); // derivative
+  return Math.atan2(-1, dydx);
+}
+```
+
+This calculates the angle perpendicular to the curve at any point. Used by the grass canvas to orient grass blades so they point "outward" from the curve surface.
+
+**Why the derivative?** The normal (perpendicular direction) at any point on a curve is rotated 90 degrees from the tangent. The tangent direction is the derivative `dy/dx`. `atan2(-1, dydx)` gives the angle pointing outward.
+
+### positionAlongCurve — Place elements on the curve
+
+```ts
+export function positionAlongCurve(strip, b, selector, transform) {
+  const elements = strip.querySelectorAll(selector);
+  elements.forEach((el, i) => {
+    const x = ((i + 1) / (n + 1)) * w; // evenly space along width
+    const y = curveY(x, w, b);
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+    el.style.transform = transform;
+  });
+}
+```
+
+Distributes elements (plants, trees, flowers) evenly along the curve. As the curve flattens during scroll, `repositionAll()` is called to move everything to their new positions.
+
+---
+
+## Procedural Grass (grassCanvas)
+
+**File:** `src/scripts/garden/grassCanvas.ts`
+
+### Seeded Random
+
+```ts
+export function seededRandom(seed: number): number {
+  const x = Math.sin(seed * 127.1) * 43758.5453;
+  return x - Math.floor(x);
+}
+```
+
+**Why not `Math.random()`?** Regular random gives different results every call. If we used it, the grass would look different on every frame/redraw, causing visual flickering. A seeded random gives the **same result for the same input**, so the grass is deterministic — it looks the same every time you redraw it.
+
+**The technique:** Multiply the seed by a large prime-like number, take the sine, multiply by another large number, and take the fractional part. This is a common trick from shader programming (GLSL) where you need cheap pseudo-random numbers.
+
+### Drawing Grass Blades
+
+```ts
+for (let x = 0; x < stripWidth; x += 4) {
+  const baseY = maxBladeH + curveY(x, stripWidth, b);
+
+  for (let j = 0; j < bladeCount; j++) {
+    // Each blade has deterministic height, lean, width, color
+    ctx.beginPath();
+    ctx.moveTo(x - width / 2, baseY);               // blade base left
+    ctx.quadraticCurveTo(cpX, cpY, tipX, tipY);      // left edge to tip
+    ctx.quadraticCurveTo(cpX + w, cpY, x + w/2, baseY); // tip to base right
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+```
+
+Every 4 pixels across the strip, 2-3 grass blades are drawn:
+
+1. **Base position** follows the curve using `curveY()`
+2. **Blade angle** follows the curve normal using `curveNormalAngle()`, plus some random lean
+3. **Shape** is drawn with two quadratic bezier curves (one for each side of the blade), meeting at the tip
+4. **Color** is randomly picked from 5 shades of dark green
+
+**Quadratic bezier curves** take 3 points: start, control point, end. The control point "pulls" the curve toward it, creating a natural grass blade shape that's wider at the base and tapers to a point.
+
+```
+        tip (end point)
+       /
+      / <- curve pulled by control point
+     /
+    /
+base (start point)
+```
+
+**Real-world example:** This is the same technique used in procedural terrain generation in games. Minecraft's grass, No Man's Sky's flora — they all use some form of seeded randomness + procedural drawing.
+
+---
+
+## Cleanup Pattern
+
+Every animation file kills its own ScrollTriggers before re-initializing:
+
+```ts
+ScrollTrigger.getAll().forEach(st => st.kill());
+```
+
+This is critical for **Astro view transitions**. When navigating between pages, the old page's ScrollTriggers would otherwise persist and conflict with the new page's animations. Killing them on init ensures a clean slate.

--- a/docs/animations/note-post-animations.md
+++ b/docs/animations/note-post-animations.md
@@ -1,0 +1,168 @@
+# Note Post Animations
+
+**File:** `src/scripts/note-post-animations.ts`
+
+Three coordinated scroll-driven animations that create a layered parallax effect on note detail pages: the content overlaps the hero, the hero fades out, and the hero background zooms.
+
+---
+
+## Overview
+
+When you open a note post, the hero section shows the title and a background image. As you scroll down:
+
+1. The main content slides **up** to overlap the hero (like a card sliding over it)
+2. The hero text **fades out**
+3. The hero background **zooms out** from 1.15x to 1x
+
+All three happen simultaneously but independently, creating a rich layered effect.
+
+---
+
+## Animation 1: Content Overlaps Hero
+
+```ts
+gsap.to(mainWrapper, {
+  y: -120,
+  ease: 'none',
+  scrollTrigger: {
+    id: 'note-hero-overlap',
+    trigger: mainWrapper,
+    start: 'top bottom',
+    end: 'top 40%',
+    scrub: true,
+  },
+});
+```
+
+### What's happening
+
+The `.note-main-wrapper` (the white content area below the hero) moves **up by 120px** as you scroll. This creates the illusion of the content "sliding over" the hero image.
+
+**`y: -120`** — Negative Y moves the element up. GSAP's `y` maps to `transform: translateY(-120px)`. Using transforms instead of `top`/`margin-top` is important because transforms are GPU-accelerated and don't trigger layout recalculation.
+
+**`start: 'top bottom'` / `end: 'top 40%'`** — The animation starts when the wrapper's top edge reaches the viewport bottom and completes when it reaches 40% from the top. This means the overlap effect finishes relatively early in the scroll, so the content is already overlapping the hero by the time the user starts reading.
+
+```
+Viewport:
+┌──────────────────────┐ 0% (top)
+│                      │
+│   [hero fading out]  │ 40% ← overlap complete here
+│                      │
+│  ┌────────────────┐  │
+│  │  content area  │  │ ← sliding up 120px
+│  │                │  │
+└──┴────────────────┴──┘ 100% (bottom) ← overlap starts here
+```
+
+### The `id` Pattern
+
+```ts
+scrollTrigger: {
+  id: 'note-hero-overlap',
+  ...
+}
+```
+
+Each trigger gets a unique ID. This allows surgical cleanup:
+
+```ts
+['note-hero-overlap', 'note-hero-fade', 'note-hero-zoom'].forEach(id => {
+  ScrollTrigger.getById(id)?.kill();
+});
+```
+
+Instead of killing ALL triggers on the page, we only kill the ones we own. This is critical because the same page might have `initRelatedNotes()` running its own ScrollTriggers. Killing everything would break those.
+
+**Real-world tip:** Always use IDs when multiple animation systems coexist on the same page. It's like namespacing your animations.
+
+---
+
+## Animation 2: Hero Content Fade
+
+```ts
+gsap.to(heroContent, {
+  opacity: 0,
+  ease: 'none',
+  scrollTrigger: {
+    id: 'note-hero-fade',
+    trigger: heroContent,
+    start: 'top top',
+    end: 'bottom top',
+    scrub: true,
+  },
+});
+```
+
+The hero text fades from fully visible to invisible as the hero scrolls out of view.
+
+**`start: 'top top'`** — Begins when the hero content reaches the top of the viewport (the user has scrolled to the hero).
+
+**`end: 'bottom top'`** — Ends when the bottom of the hero content exits the viewport top (hero fully scrolled past).
+
+This means the fade spans the entire height of the hero content. Scroll halfway through the hero = 50% opacity.
+
+---
+
+## Animation 3: Hero Background Zoom
+
+```ts
+gsap.to(heroBg, {
+  scale: 1.0,
+  ease: 'none',
+  scrollTrigger: {
+    id: 'note-hero-zoom',
+    trigger: heroBg,
+    start: 'top top',
+    end: 'bottom top',
+    scrub: true,
+  },
+});
+```
+
+The hero background image starts at `scale: 1.15` (set in CSS) and zooms out to `scale: 1.0` on scroll. This creates a subtle "breathing" effect that adds depth.
+
+**Why start at 1.15 in CSS?** The initial scale is set via CSS so the image appears zoomed in before any JavaScript runs. GSAP then animates FROM whatever the current value is (1.15) TO the specified value (1.0).
+
+**Note:** This uses `gsap.to()` (not `fromTo`) because the starting value is already set in CSS. GSAP reads the current computed style as the "from" value.
+
+---
+
+## The Combined Effect
+
+All three animations run on the same scroll range (roughly the hero section), creating a layered transition:
+
+| Scroll Position | Content Overlap | Hero Text | Hero Background |
+|-----------------|----------------|-----------|-----------------|
+| Hero entering | Starting to slide up | Fully visible | Scale 1.15 |
+| Mid-scroll | Halfway overlapped | 50% opacity | Scale ~1.07 |
+| Hero exiting | Fully overlapped (-120px) | Invisible | Scale 1.0 |
+
+**Real-world example:** This exact combination is used by:
+- Notion's marketing pages
+- Stripe's documentation pages
+- Many editorial/magazine sites (The Verge, Wired)
+
+The key insight is that layering multiple simple animations (overlap + fade + zoom) creates a much richer effect than any single complex animation.
+
+---
+
+## Common Patterns to Learn From
+
+### Scrub-based parallax
+```ts
+gsap.to(element, {
+  y: -100,           // how far to move
+  ease: 'none',      // linear for scroll-driven
+  scrollTrigger: {
+    trigger: element,
+    scrub: true,      // tie to scroll position
+  },
+});
+```
+This is the foundation of 90% of scroll animations. Change `y` to `opacity`, `scale`, `rotation`, or any CSS property.
+
+### Multiple animations, same trigger range
+You don't need one ScrollTrigger per animation. But using separate triggers gives you:
+- Individual IDs for cleanup
+- Different `start`/`end` ranges per animation
+- Easier debugging (you can comment out one without affecting others)

--- a/docs/animations/other-works-overlap.md
+++ b/docs/animations/other-works-overlap.md
@@ -1,0 +1,150 @@
+# Other Works Overlap Animation
+
+**File:** `src/scripts/other-works-overlap.ts`
+
+The simplest animation in the project — the "Other works" section slides up 200px to overlap the article content above it, creating a layered card-stack effect.
+
+---
+
+## The Full Code
+
+```ts
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function initOtherWorksOverlap() {
+  // Respect accessibility preferences
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  // Guard against duplicate initialization
+  const wrapper = document.querySelector<HTMLElement>('[data-other-works-wrapper]');
+  if (!wrapper || wrapper.dataset.overlapInited === '1') return;
+  wrapper.dataset.overlapInited = '1';
+
+  gsap.to(wrapper, {
+    y: -200,
+    ease: 'none',
+    scrollTrigger: {
+      trigger: wrapper,
+      start: 'top bottom',
+      end: 'top 60%',
+      scrub: true,
+    },
+  });
+}
+```
+
+---
+
+## Accessibility: `prefers-reduced-motion`
+
+```ts
+if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+```
+
+This is the **most important line in the file** and should be in every animation file. Some users have a system-level setting that says "I prefer less motion" — this could be due to vestibular disorders, motion sickness, or personal preference.
+
+`window.matchMedia('(prefers-reduced-motion: reduce)')` checks this OS-level setting. If enabled, we skip the animation entirely.
+
+**How to enable it (for testing):**
+- **macOS:** System Settings > Accessibility > Display > Reduce Motion
+- **iOS:** Settings > Accessibility > Motion > Reduce Motion
+- **Windows:** Settings > Accessibility > Visual Effects > Animation Effects
+- **Chrome DevTools:** Rendering panel > Emulate CSS media feature `prefers-reduced-motion`
+
+**Real-world rule:** Always respect this preference for:
+- Parallax scrolling effects
+- Auto-playing animations
+- Transitions that involve significant movement
+
+You can skip the check for:
+- Hover microinteractions (small, user-initiated)
+- Opacity fades (generally safe)
+- One-time, small transitions triggered by user action
+
+---
+
+## The Animation
+
+```ts
+gsap.to(wrapper, {
+  y: -200,
+  ease: 'none',
+  scrollTrigger: {
+    trigger: wrapper,
+    start: 'top bottom',
+    end: 'top 60%',
+    scrub: true,
+  },
+});
+```
+
+As the "Other works" section scrolls into view, it moves up by 200px. This makes it visually overlap the article content above, like a card being pushed up from below.
+
+**`start: 'top bottom'`** — Begins when the section's top enters the viewport.
+**`end: 'top 60%'`** — Completes when the section's top reaches 60% of the viewport.
+
+The animation range (from viewport bottom to 60%) is relatively short, meaning the overlap happens quickly as the section enters view.
+
+---
+
+## Patterns Worth Noting
+
+### Data Attribute Guard
+
+```ts
+if (!wrapper || wrapper.dataset.overlapInited === '1') return;
+wrapper.dataset.overlapInited = '1';
+```
+
+Same pattern as related-notes. Prevents double initialization. This is a defensive coding pattern that every animation init function should have.
+
+### Attribute Selector
+
+```ts
+document.querySelector<HTMLElement>('[data-other-works-wrapper]');
+```
+
+Using `data-*` attributes instead of CSS classes to select animation targets is a good practice:
+- **Classes** are for styling and can be renamed during CSS refactors
+- **Data attributes** are for JavaScript behavior and signal intent clearly
+
+When someone sees `data-other-works-wrapper` in the HTML, they know JavaScript is targeting it. When they see a class, it's ambiguous — is it for styles, scripts, or both?
+
+---
+
+## This File as a Template
+
+This is the simplest GSAP + ScrollTrigger pattern in the project. Use it as a starting template for new scroll animations:
+
+```ts
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+gsap.registerPlugin(ScrollTrigger);
+
+export function initMyAnimation() {
+  // 1. Respect accessibility
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  // 2. Find and guard the element
+  const el = document.querySelector<HTMLElement>('[data-my-element]');
+  if (!el || el.dataset.myInited === '1') return;
+  el.dataset.myInited = '1';
+
+  // 3. Animate
+  gsap.to(el, {
+    y: -100,           // change this to your desired property
+    ease: 'none',
+    scrollTrigger: {
+      trigger: el,
+      start: 'top bottom',
+      end: 'top 60%',
+      scrub: true,
+    },
+  });
+}
+```
+
+Change `y: -100` to any property (`opacity`, `scale`, `rotation`, `x`, etc.) and adjust `start`/`end` to control when the animation happens.

--- a/docs/animations/related-notes.md
+++ b/docs/animations/related-notes.md
@@ -1,0 +1,213 @@
+# Related Notes Animation
+
+**File:** `src/scripts/related-notes.ts`
+
+A two-phase animation: first the container height reveals itself (scroll-driven), then cards pop in with a shuffled stagger effect (triggered once). This file also handles the horizontal scroll carousel arrows.
+
+---
+
+## Phase 1: Height Reveal (Scroll-Driven)
+
+```ts
+// Measure the natural height, then collapse it
+reveal.style.height = 'auto';
+const fullHeight = reveal.offsetHeight;
+reveal.style.height = '0px';
+
+// Animate height from 0 to fullHeight on scroll
+gsap.to(reveal, {
+  height: fullHeight,
+  ease: 'none',
+  scrollTrigger: {
+    trigger: section,
+    start: 'top 90%',
+    end: 'top 50%',
+    scrub: true,
+  },
+});
+```
+
+### The "measure then collapse" trick
+
+This is a classic technique for animating to an unknown height:
+
+1. **Set height to `auto`** — the browser calculates the natural height
+2. **Read `offsetHeight`** — capture that calculated value (e.g., 340px)
+3. **Collapse to `0px`** — hide the element
+4. **Animate to the captured value** — GSAP can now tween from 0 to 340px
+
+**Why not just animate `height: auto`?** CSS (and GSAP) can't interpolate between a number and `auto`. You need two concrete numbers: `0px` and `340px`. The browser can't tween between `0px` and `auto` because `auto` isn't a number — it's an instruction to calculate.
+
+**`start: 'top 90%'`** — The reveal begins when the section's top edge is at 90% of the viewport height (near the bottom). This means the container starts growing before it's fully in view, so by the time the user sees it, it's already partially revealed.
+
+**`end: 'top 50%'`** — Fully revealed when the section reaches the middle of the viewport.
+
+```
+Viewport:
+┌──────────────────────┐ 0%
+│                      │
+│                      │ 50% ← fully revealed
+│                      │
+│                      │
+│                      │ 90% ← starts revealing
+└──────────────────────┘ 100%
+```
+
+---
+
+## Phase 2: Card Pop-In (Timeline)
+
+```ts
+const cardTl = gsap.timeline({
+  paused: true,
+  onComplete() { reveal.style.height = 'auto'; },
+  onReverseComplete() { reveal.style.height = fullHeight + 'px'; },
+});
+
+const shuffled = [...cards].sort(() => Math.random() - 0.5);
+
+cardTl.fromTo(shuffled,
+  { opacity: 0, scale: 0.8, y: 20 },
+  { opacity: 1, scale: 1, y: 0, duration: 0.4, stagger: 0.12, ease: 'back.out(1.4)' }
+);
+
+ScrollTrigger.create({
+  trigger: section,
+  start: 'top 50%',
+  onEnter: () => cardTl.play(),
+  onLeaveBack: () => cardTl.reverse(),
+});
+```
+
+### Timelines
+
+```ts
+const tl = gsap.timeline({ paused: true });
+```
+
+A **timeline** is a container for sequenced animations. Unlike standalone tweens, timelines let you:
+- Chain multiple animations in order
+- Control the whole sequence (play, pause, reverse, seek)
+- Add labels for jumping to specific points
+
+Here, `paused: true` means the timeline won't play automatically — we control when it starts.
+
+### The Shuffle Trick
+
+```ts
+const shuffled = [...cards].sort(() => Math.random() - 0.5);
+```
+
+Instead of cards animating in left-to-right (boring), they're shuffled randomly. Combined with stagger, this creates a natural "popping in" feel where cards appear in a seemingly random order.
+
+**How `sort(() => Math.random() - 0.5)` works:** The sort comparator randomly returns positive or negative, effectively shuffling the array. It's not a perfectly uniform shuffle (use Fisher-Yates for that), but it's good enough for animation ordering.
+
+### Stagger
+
+```ts
+{ stagger: 0.12 }
+```
+
+**Stagger** adds a delay between each element's animation start. With 5 cards and 0.12s stagger:
+- Card 1: starts at 0.00s
+- Card 2: starts at 0.12s
+- Card 3: starts at 0.24s
+- Card 4: starts at 0.36s
+- Card 5: starts at 0.48s
+
+Each card takes 0.4s to animate, so they overlap. This creates a cascading "wave" effect rather than all cards appearing at once.
+
+### The `back.out(1.4)` Ease
+
+```ts
+ease: 'back.out(1.4)'
+```
+
+This is what gives the cards their satisfying "bounce." The `back` ease overshoots the target and springs back:
+
+```
+value
+  1.0 ─────────── ╭─╮ ───── target
+                  ╱   ╲
+                 ╱     ╰──
+                ╱
+  0.0 ─────────╱
+              time →
+```
+
+The `1.4` parameter controls the overshoot intensity. Higher = more bounce. Default is `1.7`.
+
+Compare common eases:
+- `'none'` — linear, robotic
+- `'power2.out'` — smooth deceleration, professional
+- `'back.out(1.4)'` — playful overshoot, energetic
+- `'elastic.out(1, 0.3)'` — springy wobble, fun/cartoonish
+- `'bounce.out'` — literal bouncing ball
+
+### The fromTo Properties
+
+```ts
+{ opacity: 0, scale: 0.8, y: 20 }    // FROM: invisible, small, shifted down
+{ opacity: 1, scale: 1,   y: 0  }    // TO:   visible, full size, in place
+```
+
+This combination creates a "pop up and in" effect:
+1. Cards start invisible, 80% size, and 20px below their final position
+2. They fade in, scale up to 100%, and slide up to their natural position
+3. The `back.out` ease makes them slightly overshoot (scale briefly past 1.0)
+
+### Reversibility
+
+```ts
+onEnter: () => cardTl.play(),
+onLeaveBack: () => cardTl.reverse(),
+```
+
+If the user scrolls back up, `onLeaveBack` fires and the timeline **reverses** — cards pop back out in reverse order. This creates a polished feel where animations aren't "one and done."
+
+**`onComplete` / `onReverseComplete`:**
+```ts
+onComplete() { reveal.style.height = 'auto'; },
+onReverseComplete() { reveal.style.height = fullHeight + 'px'; },
+```
+
+After cards finish appearing, the container height is set to `auto` so it can respond to layout changes (window resize, etc.). When reversed, it goes back to the fixed pixel value so the scroll-driven height animation can take over again.
+
+---
+
+## Arrow Scroll Handlers
+
+```ts
+function updateArrows() {
+  const overflows = container.scrollWidth > container.clientWidth;
+  leftBtn.style.display = overflows ? 'flex' : 'none';
+  rightBtn.style.display = overflows ? 'flex' : 'none';
+}
+
+leftBtn.addEventListener('click', () =>
+  container.scrollBy({ left: -340, behavior: 'smooth' })
+);
+rightBtn.addEventListener('click', () =>
+  container.scrollBy({ left: 340, behavior: 'smooth' })
+);
+```
+
+This isn't GSAP — it's vanilla JS. The arrows only show when there are more cards than fit in the viewport (`scrollWidth > clientWidth`). Click scrolls by 340px (roughly one card width) using native smooth scrolling.
+
+**Real-world example:** Netflix's content rows, Spotify's album carousels, and YouTube's recommendation shelves all use this pattern — horizontal scroll with arrow navigation and overflow detection.
+
+---
+
+## Duplicate Prevention
+
+```ts
+if ((section as HTMLElement).dataset.relatedInited === '1') return;
+(section as HTMLElement).dataset.relatedInited = '1';
+```
+
+A `data-related-inited` attribute acts as a guard against running the init function twice. This can happen with:
+- Astro view transitions re-executing scripts
+- Hot module replacement during development
+- Race conditions with multiple event listeners
+
+**Pattern:** Use a data attribute on the DOM element as a "has this been initialized?" flag. Check it at the top of your init function and bail early if already done.

--- a/docs/animations/work-card-animations.md
+++ b/docs/animations/work-card-animations.md
@@ -1,0 +1,145 @@
+# Work Card Animations
+
+**File:** `src/scripts/work-card-animations.ts`
+
+A simple but effective parallax zoom effect on work card hero images. Images start zoomed in at 1.5x and scale down to 1x as they scroll through the viewport.
+
+---
+
+## The Full Code (it's only 28 lines!)
+
+```ts
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function initWorkCardAnimations() {
+  // Clean up previous triggers (view-transition safe)
+  ScrollTrigger.getAll()
+    .filter(st => st.vars.trigger && (st.vars.trigger as Element).classList?.contains('work-card-image'))
+    .forEach(st => st.kill());
+
+  document.querySelectorAll('.work-card-image').forEach(img => {
+    gsap.fromTo(img, { scale: 1.5 }, {
+      scale: 1,
+      ease: 'none',
+      scrollTrigger: {
+        trigger: img,
+        start: 'top bottom',
+        end: 'bottom top',
+        scrub: true,
+      }
+    });
+  });
+}
+```
+
+---
+
+## How It Works
+
+### `gsap.fromTo()` — Explicit Start and End
+
+```ts
+gsap.fromTo(element, { scale: 1.5 }, { scale: 1, ... });
+```
+
+There are three main GSAP animation methods:
+
+| Method | From | To | Use when |
+|--------|------|----|----------|
+| `gsap.to()` | Current CSS value | You specify | You know the end state |
+| `gsap.from()` | You specify | Current CSS value | You know the start state |
+| `gsap.fromTo()` | You specify | You specify | You know both |
+
+Here we use `fromTo` because we want to guarantee the image starts at exactly 1.5x scale and ends at exactly 1x, regardless of what CSS says.
+
+### `scrub: true` — Scroll-Linked Animation
+
+```ts
+scrollTrigger: {
+  trigger: img,
+  start: 'top bottom',    // when image top hits viewport bottom
+  end: 'bottom top',      // when image bottom hits viewport top
+  scrub: true,
+}
+```
+
+**`start: 'top bottom'`** — The animation begins the moment the image's top edge enters the viewport from below.
+
+**`end: 'bottom top'`** — The animation ends when the image's bottom edge exits the viewport at the top.
+
+This means the animation spans the **entire time the image is visible**. The image gradually scales from 1.5 to 1.0 as it travels through the viewport.
+
+```
+  ┌────────────────────┐
+  │                    │ ← viewport top (end)
+  │                    │
+  │    [  image  ]     │ ← image scrolling up, scale decreasing
+  │                    │
+  │                    │ ← viewport bottom (start)
+  └────────────────────┘
+```
+
+**`scrub: true`** means the animation is directly tied to scroll position. No playback — just pure scroll mapping.
+
+### Why `ease: 'none'`?
+
+```ts
+ease: 'none'
+```
+
+With `scrub: true`, the easing function controls how the animation maps to scroll progress. `'none'` means linear — 50% scrolled = 50% animated. If you used `'power2.out'`, the scale would change quickly at first and slow down at the end.
+
+For scroll-driven parallax effects, `'none'` feels most natural because the user is in direct control. Non-linear easing can feel "slippery" or disconnected when scrubbing.
+
+### Selective Cleanup
+
+```ts
+ScrollTrigger.getAll()
+  .filter(st => st.vars.trigger && (st.vars.trigger as Element).classList?.contains('work-card-image'))
+  .forEach(st => st.kill());
+```
+
+Instead of killing ALL ScrollTriggers (which would break other animations on the page), this filters for only the ones attached to `.work-card-image` elements. This is important because:
+
+1. **View transitions** in Astro re-run scripts. Without cleanup, you'd get duplicate triggers.
+2. **Other animations** (like related-notes) might be running on the same page and shouldn't be affected.
+
+**Real-world example:** This parallax zoom is a very common pattern. You see it on:
+- Medium article hero images
+- Apple product showcase pages
+- Portfolio sites with project cards
+
+The effect creates depth — the image feels like it's on a different layer than the rest of the page, subtly zooming as you scroll past it.
+
+---
+
+## Making It Your Own
+
+Want to try different effects? Here are some variations:
+
+**Parallax slide (image moves slower than scroll):**
+```ts
+gsap.fromTo(img, { y: -50 }, {
+  y: 50,
+  scrollTrigger: { trigger: img, start: 'top bottom', end: 'bottom top', scrub: true }
+});
+```
+
+**Rotate on scroll:**
+```ts
+gsap.fromTo(img, { rotation: -5 }, {
+  rotation: 5,
+  scrollTrigger: { trigger: img, start: 'top bottom', end: 'bottom top', scrub: true }
+});
+```
+
+**Fade in as it enters:**
+```ts
+gsap.fromTo(img, { opacity: 0 }, {
+  opacity: 1,
+  scrollTrigger: { trigger: img, start: 'top 80%', end: 'top 50%', scrub: true }
+});
+```

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -13,19 +13,22 @@ const slug = entry.id;
 const href = `/works/${slug}`;
 ---
 
+<!-- Work card: text on left, hero image on right (stacks on mobile) -->
 <a
   href={href}
   class="work-card-container group block"
 >
   <div class="flex flex-col md:flex-row gap-8 md:gap-12 items-start">
+    <!-- Card metadata (sticky on desktop) -->
     <div class="work-card-content w-full md:w-1/3 flex flex-col gap-2">
-      <p class="text-syoro/60 font-sans text-xs uppercase tracking-wide">{duration}</p>
+      <p class="text-syoro/60 font-sans text-base md:text-lg uppercase tracking-wide">{duration}</p>
       <h2 class="text-syoro font-serif text-2xl md:text-3xl">{title}</h2>
-      <h3 class="text-syoro font-sans font-bold text-sm">{role}</h3>
+      <h3 class="text-syoro font-sans text-lg md:text-xl">{role}</h3>
       {description && (
-        <p class="text-syoro/80 font-serif text-lg md:text-xl mt-4 leading-relaxed">{description}</p>
+        <p class="text-syoro/80 font-serif text-lg md:text-xl mt-10 leading-relaxed">{description}</p>
       )}
     </div>
+    <!-- Hero image with parallax zoom (see work-card-animations.ts) -->
     <div class="w-full md:w-2/3 overflow-hidden rounded-lg">
       {heroImage ? (
         <img
@@ -44,35 +47,14 @@ const href = `/works/${slug}`;
   @media (min-width: 768px) {
     .work-card-content {
       position: sticky;
-      top: 0;
+      top: 30vh;
     }
   }
 </style>
 
+<!-- Parallax zoom animation: images scale 1.5→1 on scroll -->
 <script>
-  import gsap from 'gsap';
-  import ScrollTrigger from 'gsap/ScrollTrigger';
-
-  gsap.registerPlugin(ScrollTrigger);
-
-  function initWorkCardAnimations() {
-    ScrollTrigger.getAll()
-      .filter(st => st.vars.trigger && (st.vars.trigger as Element).classList?.contains('work-card-image'))
-      .forEach(st => st.kill());
-
-    document.querySelectorAll('.work-card-image').forEach(img => {
-      gsap.fromTo(img, { scale: 1.5}, {
-        scale: 1,
-        ease: 'none',
-        scrollTrigger: {
-          trigger: img,
-          start: 'top bottom',
-          end: 'bottom top',
-          scrub: true,
-        }
-      });
-    });
-  }
+  import { initWorkCardAnimations } from '../scripts/work-card-animations';
 
   document.addEventListener('DOMContentLoaded', initWorkCardAnimations);
   document.addEventListener('astro:page-load', initWorkCardAnimations);

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -8,79 +8,72 @@ interface Props {
 const { entry } = Astro.props;
 if (!entry?.data) return null;
 const { data } = entry;
-const { company, role, duration, heroImage, title } = data;
+const { role, duration, heroImage, title, description } = data;
 const slug = entry.id;
 const href = `/works/${slug}`;
-const bgImage = heroImage;
 ---
 
 <a
   href={href}
-  class="work-card-container group block relative w-full aspect-[4/3] min-h-[200px] rounded-xl overflow-visible"
-  style="perspective: 800px"
+  class="work-card-container group block"
 >
-  {Array.from({ length: 25 }, (_, i) => (
-    <div class={`work-card-tracker tr-${i + 1}`} />
-  ))}
-  <div
-    class="work-card absolute inset-0 z-0 flex flex-col justify-end rounded-xl transition-transform duration-125 ease-[cubic-bezier(0.4,0,0.2,1)] [transform-style:preserve-3d]"
-    style={bgImage ? `background-image: url('${bgImage}'); background-size: cover; background-position: center;` : 'background: #374151;'}
-  >
-    <div class="absolute bottom-0 w-full flex flex-col justify-end bg-white/70 dark:bg-cardbg/80 backdrop-blur-sm shadow-lg p-5">
-      <div class="flex flex-row items-center justify-between">
-        <div class="flex flex-col">
-          <h2 class="text-syoro font-sans font-bold text-xl">{title} | {company}</h2>
-          <h3 class="text-syoro font-sans text-lg uppercase">{role}</h3>
-        </div>
-        <div class="flex flex-row place-self-end">
-          {duration && (
-            <p class="text-syoro font-sans text-lg uppercase">
-              {duration}
-              <span class="hidden group-hover:inline text-xl ml-1">→</span>
-            </p>
-          )}
-        </div>
-      </div>
+  <div class="flex flex-col md:flex-row gap-8 md:gap-12 items-start">
+    <div class="work-card-content w-full md:w-1/3 flex flex-col gap-2">
+      <p class="text-syoro/60 font-sans text-xs uppercase tracking-wide">{duration}</p>
+      <h2 class="text-syoro font-serif text-2xl md:text-3xl">{title}</h2>
+      <h3 class="text-syoro font-sans font-bold text-sm">{role}</h3>
+      {description && (
+        <p class="text-syoro/80 font-serif text-lg md:text-xl mt-4 leading-relaxed">{description}</p>
+      )}
+    </div>
+    <div class="w-full md:w-2/3 overflow-hidden rounded-lg">
+      {heroImage ? (
+        <img
+          src={heroImage}
+          alt={title}
+          class="work-card-image w-full aspect-[4/3] object-cover"
+        />
+      ) : (
+        <div class="w-full aspect-[4/3] bg-gray-200 dark:bg-gray-700" />
+      )}
     </div>
   </div>
 </a>
 
 <style>
-  .work-card-container {
-    cursor: pointer;
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(5, 1fr);
+  @media (min-width: 768px) {
+    .work-card-content {
+      position: sticky;
+      top: 0;
+    }
   }
-
-  .work-card-tracker {
-    position: relative;
-    z-index: 10;
-  }
-
-  .tr-1:hover ~ .work-card { transform: rotateX(20deg) rotateY(-10deg); }
-  .tr-2:hover ~ .work-card { transform: rotateX(20deg) rotateY(-5deg); }
-  .tr-3:hover ~ .work-card { transform: rotateX(20deg) rotateY(0deg); }
-  .tr-4:hover ~ .work-card { transform: rotateX(20deg) rotateY(5deg); }
-  .tr-5:hover ~ .work-card { transform: rotateX(20deg) rotateY(10deg); }
-  .tr-6:hover ~ .work-card { transform: rotateX(10deg) rotateY(-10deg); }
-  .tr-7:hover ~ .work-card { transform: rotateX(10deg) rotateY(-5deg); }
-  .tr-8:hover ~ .work-card { transform: rotateX(10deg) rotateY(0deg); }
-  .tr-9:hover ~ .work-card { transform: rotateX(10deg) rotateY(5deg); }
-  .tr-10:hover ~ .work-card { transform: rotateX(10deg) rotateY(10deg); }
-  .tr-11:hover ~ .work-card { transform: rotateX(0deg) rotateY(-10deg); }
-  .tr-12:hover ~ .work-card { transform: rotateX(0deg) rotateY(-5deg); }
-  .tr-13:hover ~ .work-card { transform: rotateX(0deg) rotateY(0deg); }
-  .tr-14:hover ~ .work-card { transform: rotateX(0deg) rotateY(5deg); }
-  .tr-15:hover ~ .work-card { transform: rotateX(0deg) rotateY(10deg); }
-  .tr-16:hover ~ .work-card { transform: rotateX(-10deg) rotateY(-10deg); }
-  .tr-17:hover ~ .work-card { transform: rotateX(-10deg) rotateY(-5deg); }
-  .tr-18:hover ~ .work-card { transform: rotateX(-10deg) rotateY(0deg); }
-  .tr-19:hover ~ .work-card { transform: rotateX(-10deg) rotateY(5deg); }
-  .tr-20:hover ~ .work-card { transform: rotateX(-10deg) rotateY(10deg); }
-  .tr-21:hover ~ .work-card { transform: rotateX(-20deg) rotateY(-10deg); }
-  .tr-22:hover ~ .work-card { transform: rotateX(-20deg) rotateY(-5deg); }
-  .tr-23:hover ~ .work-card { transform: rotateX(-20deg) rotateY(0deg); }
-  .tr-24:hover ~ .work-card { transform: rotateX(-20deg) rotateY(5deg); }
-  .tr-25:hover ~ .work-card { transform: rotateX(-20deg) rotateY(10deg); }
 </style>
+
+<script>
+  import gsap from 'gsap';
+  import ScrollTrigger from 'gsap/ScrollTrigger';
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  function initWorkCardAnimations() {
+    ScrollTrigger.getAll()
+      .filter(st => st.vars.trigger && (st.vars.trigger as Element).classList?.contains('work-card-image'))
+      .forEach(st => st.kill());
+
+    document.querySelectorAll('.work-card-image').forEach(img => {
+      gsap.fromTo(img, { scale: 1.5}, {
+        scale: 1,
+        ease: 'none',
+        scrollTrigger: {
+          trigger: img,
+          start: 'top bottom',
+          end: 'bottom top',
+          scrub: true,
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initWorkCardAnimations);
+  document.addEventListener('astro:page-load', initWorkCardAnimations);
+</script>

--- a/src/content/notes/HomePageRedesign.md
+++ b/src/content/notes/HomePageRedesign.md
@@ -1,0 +1,98 @@
+---
+title: 'Home Page Architecture'
+description: 'Documentation of the home page redesign — layout, animation system, component structure, and data flow.'
+pubDate: 'Mar 10 2026'
+tags: ['tech']
+featured: false
+maturity: 'seed'
+publish: false
+---
+
+# Home Page Architecture
+
+## Overview
+The home page (`src/pages/index.astro`) is a centered, minimal layout with a hero intro section and a vertically stacked list of work case studies. It uses Astro view transitions and CSS entrance animations.
+
+## Page Structure
+
+```
+index.astro
+├── BaseHead (SEO, fonts, global CSS)
+├── ClientRouter (Astro view transitions)
+├── <script is:inline> (entrance animation logic)
+├── <main>
+│   ├── Header (logo + nav)
+│   ├── Hero Section (#Intro-text) — centered text
+│   │   ├── h1 "Hi, I'm Ruwaiz"
+│   │   ├── p — tagline
+│   │   └── p — "Currently building..." with Link
+│   └── Works Section (#Works) — vertical stack
+│       └── WorkCard × N
+└── Footer (contact section with GSAP icon morphing)
+```
+
+## Components
+
+### WorkCard (`src/components/WorkCard.astro`)
+Each work entry renders as a side-by-side card:
+- **Left (~40%)**: Duration (small uppercase), Title (large serif), Role (bold), Description
+- **Right (~60%)**: Hero image with rounded corners and subtle scale hover effect
+- Stacks vertically on mobile (`flex-col` → `md:flex-row`)
+- Data comes from `src/content/works/*.mdx` frontmatter:
+  - `title`, `description`, `company`, `role`, `duration`, `heroImage`
+
+### Link (`src/components/mdxComponents/Link.astro`)
+Animated underline link with hover color shift to `--color-konpeki`.
+
+## Entrance Animation System
+
+The page has two animation states managed via body/html classes:
+
+### First Visit (`animate-in`)
+Applied when the user navigates to `/` for the first time (not returning from a work page).
+
+```
+body.animate-in .index-intro    → HeroSectionIntro (slide up 20px, fade in, 0.3s delay)
+body.animate-in .work-cards-container → selectedSectionIntro (slide up 70px, fade in, 0.8s delay)
+```
+
+### Return Visit (`returned-from-work`)
+Applied when returning from `/works/*` (detected via `document.referrer` or `sessionStorage.skipIndexAnimations`).
+
+```
+body.returned-from-work .index-intro → opacity: 1, no animation
+body.returned-from-work .work-cards-container → opacity: 1, no animation
+```
+
+### Detection Logic (`<script is:inline>`)
+1. On initial load: checks `document.referrer` for `/works/` or `sessionStorage.skipIndexAnimations`
+2. On Astro page transitions (`astro:page-load`): re-applies the correct class to the new body element
+3. Uses `requestAnimationFrame` double-tap for timing safety
+
+### How `skipIndexAnimations` Gets Set
+The Navigation component (`src/components/Navigation.astro`) sets `sessionStorage.setItem('skipIndexAnimations', '1')` when the logo is clicked, so returning to the index doesn't replay the entrance animation.
+
+## View Transitions
+Each work card wrapper has `transition:name={work-${entry.id}}` for smooth morphing between the index and work detail pages. The `ClientRouter` component enables Astro's built-in view transition system.
+
+## Footer Reveal Pattern
+The footer uses a "reveal" pattern where it sits behind the main content (sticky, z-0) and becomes visible as you scroll past the content (z-1). Managed via `.footer-reveal` and `.footer-reveal-content` classes in `global.css`.
+
+## Styling
+- **Fonts**: IBM Plex Serif (body/headings), Saira Condensed (labels/UI), Caveat (logo)
+- **Colors**: `--color-syoro` (text), `--color-backgroundcolor` (bg), `--color-link` (links)
+- **Dark mode**: CSS variables swap in `@media (prefers-color-scheme: dark)` via `global.css`
+- **Responsive padding**: `px-6 md:px-12 lg:px-20` on the main container
+
+## Key Files
+| File | Purpose |
+|------|---------|
+| `src/pages/index.astro` | Home page layout and animations |
+| `src/components/WorkCard.astro` | Individual work case study card |
+| `src/components/Header.astro` | Site header with navigation |
+| `src/components/Navigation.astro` | Nav menu with animation skip logic |
+| `src/components/Footer.astro` | Contact section with GSAP morphing |
+| `src/components/mdxComponents/Link.astro` | Animated link component |
+| `src/styles/global.css` | Theme colors, fonts, footer-reveal |
+| `src/content/works/*.mdx` | Work entry content and frontmatter |
+| `src/content.config.ts` | Collection schemas |

--- a/src/layouts/WorkLayout.astro
+++ b/src/layouts/WorkLayout.astro
@@ -28,11 +28,7 @@ const workTransitionStyle = transitionName
     <div class="footer-reveal-content px-20">
       <Header />
       <main transition:name={transitionName}>
-        <!-- Back link: set flag so index skips entrance animations -->
-        
-        
-        <!-- Hero title (Itti-style large headline) -->
-         
+        <!-- Title + metadata header -->
         <div>
           <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mt-20 mb-10">
             <h1 class="text-syoro dark:text-syoro font-sans text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold leading-none max-w-3xl">
@@ -54,7 +50,7 @@ const workTransitionStyle = transitionName
         </div>
         
 
-        <!-- Hero image -->
+        <!-- Hero image: shrinks + blurs on scroll (see work-hero-scroll.ts) -->
         <section class="relative mb-0" id="hero-image-section">
           <div
             class="hero-image-wrapper relative z-0 w-screen max-w-[100vw] ml-[calc(50%-50vw)] content-end overflow-hidden mt-15 
@@ -73,16 +69,11 @@ const workTransitionStyle = transitionName
           )}
           </section>
         
-        <!-- Overview / description -->
-        
-        
-
-        
-
         <!-- Main content (MDX) -->
         <article class="work-article text-syoro font-serif text-2xl w-4/5 mx-auto">
           <slot />
         </article>
+        <!-- Other works: slides up to overlap article on scroll (see other-works-overlap.ts) -->
         <div class="other-works-overlap" data-other-works-wrapper>
           <OtherWorksSection currentSlug={Astro.url.pathname.replace('/works/', '').replace(/\/$/, '')} />
         </div>
@@ -93,46 +84,9 @@ const workTransitionStyle = transitionName
   </body>
 </html>
 
+<!-- Hero scroll height + blur effect (see work-hero-scroll.ts) -->
 <script>
-  function initHeroScrollHeight() {
-    const hero = document.getElementById('hero-image');
-    if (!hero || hero.dataset.heroScrollInited === '1') return;
-    hero.dataset.heroScrollInited = '1';
-
-    let initialHeightPx = 0.8 * window.innerHeight;
-    let ticking = false;
-    const maxBlurPx = 8;
-
-    function updateHeight() {
-      if (!hero) return;
-      const top = hero.getBoundingClientRect().top;
-      const heightPx = Math.max(0, initialHeightPx + top);
-      hero.style.height = heightPx + 'px';
-      const shrinkRatio = 1 - heightPx / initialHeightPx; //(0 when full height, 1 when height is 0).
-      const blurPx = Math.max(0,shrinkRatio * maxBlurPx);
-      hero.style.filter = blurPx > 0 ? 'blur(' + blurPx + 'px)' : 'none'; //when blurPx > 0, and to 'none' when the hero is at full height.
-    }
-
-    function onScroll() {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(function () {
-          updateHeight();
-          ticking = false;
-        });
-      }
-
-    }
-
-    function onResize() {
-      initialHeightPx = 0.8 * window.innerHeight;
-      updateHeight();
-    }
-
-    updateHeight();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onResize);
-  }
+  import { initHeroScrollHeight } from '../scripts/work-hero-scroll';
 
   function runIfWorkPage() {
     if (window.location.pathname.startsWith('/works/')) {
@@ -140,10 +94,7 @@ const workTransitionStyle = transitionName
     }
   }
 
-  // After view-transition swap (client-side nav to work page)
   document.addEventListener('astro:page-load', runIfWorkPage);
-
-  // Full page load of a work URL (DOM already has #hero-image)
   if (document.readyState === 'complete') {
     runIfWorkPage();
   } else {
@@ -151,29 +102,9 @@ const workTransitionStyle = transitionName
   }
 </script>
 
+<!-- "Other works" overlap animation (see other-works-overlap.ts) -->
 <script>
-  import gsap from 'gsap';
-  import { ScrollTrigger } from 'gsap/ScrollTrigger';
-
-  gsap.registerPlugin(ScrollTrigger);
-
-  function initOtherWorksOverlap() {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    const wrapper = document.querySelector<HTMLElement>('[data-other-works-wrapper]');
-    if (!wrapper || wrapper.dataset.overlapInited === '1') return;
-    wrapper.dataset.overlapInited = '1';
-
-    gsap.to(wrapper, {
-      y: -200,
-      ease: 'none',
-      scrollTrigger: {
-        trigger: wrapper,
-        start: 'top bottom',
-        end: 'top 60%',
-        scrub: true,
-      },
-    });
-  }
+  import { initOtherWorksOverlap } from '../scripts/other-works-overlap';
 
   function runOverlapIfWorkPage() {
     if (window.location.pathname.startsWith('/works/')) {

--- a/src/layouts/notesPost.astro
+++ b/src/layouts/notesPost.astro
@@ -27,6 +27,8 @@ const workTransitionStyle = transitionName
   <body class="footer-reveal bg-backgroundcolor">
     <main class="w-full sm:w-[90%] mx-auto" transition:name={transitionName}>
       <Header />
+
+      <!-- Hero section: title, metadata, background image -->
       <NotePostHero
         title={title}
         description={description}
@@ -36,73 +38,21 @@ const workTransitionStyle = transitionName
         tags={tags}
         maturity={maturity}
       />
+
+      <!-- Main content wrapper: overlaps hero on scroll (see note-post-animations.ts) -->
       <div class="note-main-wrapper relative z-10 bg-backgroundcolor w-screen max-w-[100vw] ml-[calc(50%-50vw)]">
         <NoteMain>
           <slot />
         </NoteMain>
+        <!-- Related notes carousel -->
         <RelatedNotes currentTags={tags} currentTitle={title} />
       </div>
     </main>
     <Footer />
 
+    <!-- Scroll animations: hero overlap, fade-out, and zoom (see note-post-animations.ts) -->
     <script>
-      import gsap from 'gsap';
-      import { ScrollTrigger } from 'gsap/ScrollTrigger';
-      gsap.registerPlugin(ScrollTrigger);
-
-      function initNotePostAnimations() {
-        // Kill only our own ScrollTriggers (not RelatedNotes' ones)
-        ['note-hero-overlap', 'note-hero-fade', 'note-hero-zoom'].forEach(id => {
-          ScrollTrigger.getById(id)?.kill();
-        });
-
-        const heroContent = document.getElementById('note-hero-content');
-        const heroBg = document.getElementById('note-hero-bg');
-        const mainWrapper = document.querySelector('.note-main-wrapper');
-
-        if (!heroContent || !mainWrapper) return;
-
-        // NoteMain overlaps hero as user scrolls
-        gsap.to(mainWrapper, {
-          y: -120,
-          ease: 'none',
-          scrollTrigger: {
-            id: 'note-hero-overlap',
-            trigger: mainWrapper,
-            start: 'top bottom',
-            end: 'top 40%',
-            scrub: true,
-          },
-        });
-
-        // Hero content fades out on scroll
-        gsap.to(heroContent, {
-          opacity: 0,
-          ease: 'none',
-          scrollTrigger: {
-            id: 'note-hero-fade',
-            trigger: heroContent,
-            start: 'top top',
-            end: 'bottom top',
-            scrub: true,
-          },
-        });
-
-        // Hero background zooms out from 1.15 to 1.0
-        if (heroBg) {
-          gsap.to(heroBg, {
-            scale: 1.0,
-            ease: 'none',
-            scrollTrigger: {
-              id: 'note-hero-zoom',
-              trigger: heroBg,
-              start: 'top top',
-              end: 'bottom top',
-              scrub: true,
-            },
-          });
-        }
-      }
+      import { initNotePostAnimations } from '../scripts/note-post-animations';
 
       document.addEventListener('astro:page-load', initNotePostAnimations);
       document.addEventListener('DOMContentLoaded', initNotePostAnimations);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,11 @@ const works = await getCollection('works', ({ data }) => data.publish);
         <ClientRouter />
 	</head>
 	<body class="footer-reveal bg-backgroundcolor">
+		<!--
+			Entrance animation gate (is:inline — must run before hydration to prevent FOUC).
+			Adds 'animate-in' on first visit or 'returned-from-work' when navigating back
+			from a work page, so CSS can show/animate content immediately.
+		-->
 		<script is:inline>
 			(function applyIndexEntrance() {
 				var fromWork = document.referrer.indexOf('/works/') !== -1 || sessionStorage.getItem('skipIndexAnimations') === '1';
@@ -50,11 +55,14 @@ const works = await getCollection('works', ({ data }) => data.publish);
 		</script>
 		<main class="footer-reveal-content w-full px-6 md:px-12 lg:px-20">
       <Header />
-      <section id="Intro-text" class="text-2xl xl:text-3xl w-full sm:w-3/4 md:w-3/4 xl:w-[40%] font-serif my-30 text-syoro">
-        <p class="index-intro text-lg  mb-2 text-syoro/60" >Currently Senior UX Designer at <Link href="https://nordeus.com/" class="text-link">Nordeus.</Link></p>
-        <p class="index-intro">I design and prototype systems that help people stay consistent over time.</p> 
+
+      <!-- Intro: role + tagline -->
+      <section id="Intro-text" class="w-full sm:w-3/4 md:w-3/4 xl:w-[50%] font-serif my-30 text-syoro">
+        <p class="index-intro text-lg  mb-2 text-syoro/60 font-sans" >Currently Senior UX Designer at <Link href="https://nordeus.com/" class="text-link">Nordeus.</Link></p>
+        <p class="index-intro text-2xl md:text-3xl xl:text-4xl ">I design and optimize product systems that improve onboarding, retention, and long-term user motivation</p> 
         
         </section>
+    <!-- Selected works grid (parallax zoom via work-card-animations.ts) -->
     <section class="work-cards-container w-full mx-auto mt-40 mb-20" id="Works">
       <h2 class="text-syoro opacity-50 font-sans text-lg uppercase mb-10">Selected works</h2>
       <div class="flex flex-col gap-16 md:gap-24">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,18 +48,16 @@ const works = await getCollection('works', ({ data }) => data.publish);
 			document.addEventListener('astro:page-load', ensureIndexEntrance);
 			requestAnimationFrame(function() { requestAnimationFrame(ensureIndexEntrance); });
 		</script>
-		<main class="footer-reveal-content w-full px-20">
+		<main class="footer-reveal-content w-full px-6 md:px-12 lg:px-20">
       <Header />
-    <section id="Intro-text" class="text-2xl xl:text-3xl w-full sm:w-3/4 md:w-3/4 xl:w-1/2 font-serif my-20 text-syoro">
-      <p class="index-intro">I design and prototype systems that help people stay consistent over time.</p> 
-      <p class="index-intro mt-10" >Currently building something cool at <Link href="https://nordeus.com/" class="text-link">Nordeus.</Link></p>
-    </section>
-    <section
-      class="rounded-xl bg-white dark:bg-cardbg p-5 mt-10 work-cards-container"
-      id="Works"
-    >
-      <h2 class="text-syoro opacity-50 font-sans text-lg uppercase">Selected works</h2>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-10 mt-5">
+      <section id="Intro-text" class="text-2xl xl:text-3xl w-full sm:w-3/4 md:w-3/4 xl:w-[40%] font-serif my-30 text-syoro">
+        <p class="index-intro text-lg  mb-2 text-syoro/60" >Currently Senior UX Designer at <Link href="https://nordeus.com/" class="text-link">Nordeus.</Link></p>
+        <p class="index-intro">I design and prototype systems that help people stay consistent over time.</p> 
+        
+        </section>
+    <section class="work-cards-container w-full mx-auto mt-40 mb-20" id="Works">
+      <h2 class="text-syoro opacity-50 font-sans text-lg uppercase mb-10">Selected works</h2>
+      <div class="flex flex-col gap-16 md:gap-24">
         {works.map((entry) => (
           <div
             class="work-card-intro"
@@ -69,7 +67,6 @@ const works = await getCollection('works', ({ data }) => data.publish);
           </div>
         ))}
       </div>
-      <h2 class="text-syoro opacity-50 font-sans text-lg uppercase rotate-180">Selected works</h2>
     </section>
 
 		</main>

--- a/src/scripts/note-post-animations.ts
+++ b/src/scripts/note-post-animations.ts
@@ -1,0 +1,67 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+/**
+ * Scroll-driven animations for note post pages:
+ * - NoteMain overlaps the hero section as user scrolls down
+ * - Hero content fades out on scroll
+ * - Hero background zooms out from 1.15 → 1.0
+ *
+ * Each trigger has a unique ID so we can clean up without
+ * affecting other ScrollTriggers (e.g. RelatedNotes).
+ */
+export function initNotePostAnimations() {
+  // Kill only our own ScrollTriggers (not RelatedNotes' ones)
+  ['note-hero-overlap', 'note-hero-fade', 'note-hero-zoom'].forEach(id => {
+    ScrollTrigger.getById(id)?.kill();
+  });
+
+  const heroContent = document.getElementById('note-hero-content');
+  const heroBg = document.getElementById('note-hero-bg');
+  const mainWrapper = document.querySelector<HTMLElement>('.note-main-wrapper');
+
+  if (!heroContent || !mainWrapper) return;
+
+  // NoteMain overlaps hero as user scrolls
+  gsap.to(mainWrapper, {
+    y: -120,
+    ease: 'none',
+    scrollTrigger: {
+      id: 'note-hero-overlap',
+      trigger: mainWrapper,
+      start: 'top bottom',
+      end: 'top 40%',
+      scrub: true,
+    },
+  });
+
+  // Hero content fades out on scroll
+  gsap.to(heroContent, {
+    opacity: 0,
+    ease: 'none',
+    scrollTrigger: {
+      id: 'note-hero-fade',
+      trigger: heroContent,
+      start: 'top top',
+      end: 'bottom top',
+      scrub: true,
+    },
+  });
+
+  // Hero background zooms out from 1.15 to 1.0
+  if (heroBg) {
+    gsap.to(heroBg, {
+      scale: 1.0,
+      ease: 'none',
+      scrollTrigger: {
+        id: 'note-hero-zoom',
+        trigger: heroBg,
+        start: 'top top',
+        end: 'bottom top',
+        scrub: true,
+      },
+    });
+  }
+}

--- a/src/scripts/other-works-overlap.ts
+++ b/src/scripts/other-works-overlap.ts
@@ -1,0 +1,28 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+/**
+ * "Other works" section slides up to overlap the article content
+ * as the user scrolls towards the bottom of a work detail page.
+ * Respects prefers-reduced-motion and guards against duplicate init.
+ */
+export function initOtherWorksOverlap() {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const wrapper = document.querySelector<HTMLElement>('[data-other-works-wrapper]');
+  if (!wrapper || wrapper.dataset.overlapInited === '1') return;
+  wrapper.dataset.overlapInited = '1';
+
+  gsap.to(wrapper, {
+    y: -200,
+    ease: 'none',
+    scrollTrigger: {
+      trigger: wrapper,
+      start: 'top bottom',
+      end: 'top 60%',
+      scrub: true,
+    },
+  });
+}

--- a/src/scripts/work-card-animations.ts
+++ b/src/scripts/work-card-animations.ts
@@ -1,0 +1,28 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+/**
+ * Parallax zoom effect on work-card hero images.
+ * Images scale from 1.5 → 1 as they scroll through the viewport.
+ * Cleans up previous triggers before re-initializing (view-transition safe).
+ */
+export function initWorkCardAnimations() {
+  ScrollTrigger.getAll()
+    .filter(st => st.vars.trigger && (st.vars.trigger as Element).classList?.contains('work-card-image'))
+    .forEach(st => st.kill());
+
+  document.querySelectorAll('.work-card-image').forEach(img => {
+    gsap.fromTo(img, { scale: 1.5 }, {
+      scale: 1,
+      ease: 'none',
+      scrollTrigger: {
+        trigger: img,
+        start: 'top bottom',
+        end: 'bottom top',
+        scrub: true,
+      }
+    });
+  });
+}

--- a/src/scripts/work-hero-scroll.ts
+++ b/src/scripts/work-hero-scroll.ts
@@ -1,0 +1,45 @@
+/**
+ * Scroll-driven hero image height & blur effect for work detail pages.
+ * As the user scrolls down, the hero image shrinks and gains a blur filter.
+ * Pure vanilla JS — no GSAP dependency.
+ */
+export function initHeroScrollHeight() {
+  const hero = document.getElementById('hero-image');
+  if (!hero || hero.dataset.heroScrollInited === '1') return;
+  hero.dataset.heroScrollInited = '1';
+
+  let initialHeightPx = 0.8 * window.innerHeight;
+  let ticking = false;
+  const maxBlurPx = 8;
+
+  function updateHeight() {
+    if (!hero) return;
+    const top = hero.getBoundingClientRect().top;
+    const heightPx = Math.max(0, initialHeightPx + top);
+    hero.style.height = heightPx + 'px';
+
+    // Blur increases as the hero shrinks (0 at full height, maxBlurPx at 0 height)
+    const shrinkRatio = 1 - heightPx / initialHeightPx;
+    const blurPx = Math.max(0, shrinkRatio * maxBlurPx);
+    hero.style.filter = blurPx > 0 ? 'blur(' + blurPx + 'px)' : 'none';
+  }
+
+  function onScroll() {
+    if (!ticking) {
+      ticking = true;
+      requestAnimationFrame(function () {
+        updateHeight();
+        ticking = false;
+      });
+    }
+  }
+
+  function onResize() {
+    initialHeightPx = 0.8 * window.innerHeight;
+    updateHeight();
+  }
+
+  updateHeight();
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onResize);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily UI/animation refactors across the home, work, and note post layouts; risk is moderate due to new ScrollTrigger/scroll listeners interacting with Astro view transitions and potential for duplicate/lingering triggers if initialization/cleanup is off.
> 
> **Overview**
> Implements a redesigned home page layout (updated intro copy, responsive padding, and a vertical *Selected works* stack) while keeping entrance animations gated via `animate-in`/`returned-from-work` classes for view-transition navigations.
> 
> Refactors `WorkCard.astro` from a 3D hover/tilt card into a two-column text+image layout (with sticky text on desktop) and adds a new GSAP parallax zoom on `.work-card-image` via `initWorkCardAnimations()`.
> 
> Moves inline scroll logic out of layouts into reusable scripts: adds `work-hero-scroll.ts` (work hero height shrink + blur), `other-works-overlap.ts` (scroll overlap for the “Other works” section), and `note-post-animations.ts` (note hero overlap + fade + background zoom), updating `WorkLayout.astro` and `notesPost.astro` to import/init these on `DOMContentLoaded` and `astro:page-load`.
> 
> Adds animation documentation markdown files under `docs/animations/` and a draft note `HomePageRedesign.md` describing the new home architecture.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9478a177d8b4d5d79a42d12010336209a1a994fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->